### PR TITLE
feat :: user profile role 반환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,8 +13,11 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
 
-    annotationProcessor 'org.projectlombok:lombok:1.18.30'
     compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+    testCompileOnly 'org.projectlombok:lombok:1.18.30'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.30'
 
     implementation 'net.devh:grpc-client-spring-boot-starter:2.15.0.RELEASE'
     implementation 'net.devh:grpc-server-spring-boot-starter:2.15.0.RELEASE'

--- a/src/main/java/com/example/user/domain/controller/UserController.java
+++ b/src/main/java/com/example/user/domain/controller/UserController.java
@@ -2,6 +2,7 @@ package com.example.user.domain.controller;
 
 import com.example.user.domain.dto.request.UserNameUpdateRequest;
 
+import com.example.user.domain.dto.response.MyUserResponse;
 import com.example.user.domain.dto.response.UserResponse;
 import com.example.user.domain.service.UserService;
 import com.example.user.global.dto.ResponseDto;
@@ -18,6 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RequestMapping("/users")
 public class UserController {
   private final UserService userService;
+
 
   @GetMapping("/profile")
   public ResponseEntity<ResponseDto<UserResponse>> findUserById(@RequestHeader("user-id") String userId) {

--- a/src/main/java/com/example/user/domain/dto/response/MyUserResponse.java
+++ b/src/main/java/com/example/user/domain/dto/response/MyUserResponse.java
@@ -1,6 +1,6 @@
 package com.example.user.domain.dto.response;
 
-public record UserResponse (
+public record MyUserResponse(
         String userId,
         String name,
         Long remainToken,

--- a/src/main/java/com/example/user/domain/mapper/UserMapper.java
+++ b/src/main/java/com/example/user/domain/mapper/UserMapper.java
@@ -15,6 +15,7 @@ public interface UserMapper {
 
   User toEntity(UserCreateRequest request, UserRole role);
 
+
   UserResponse toDto(User user);
 
   UserIdResponse toUserIdResponse(User user);

--- a/src/main/java/com/example/user/domain/service/UserService.java
+++ b/src/main/java/com/example/user/domain/service/UserService.java
@@ -28,6 +28,10 @@ public class UserService {
   private final UserMapper userMapper;
   private final FileStorage fileStorage;
 
+  public void getMe() {
+
+  }
+
   @Transactional
   public void register(UserCreateRequest request) {
     String userId = request.userId();
@@ -83,6 +87,7 @@ public class UserService {
   private User getUserById(String userId) {
     User user = userRepository.findByUserId(userId)
             .orElseThrow(NotFoundUserException::getInstance);
+    
     return user;
   }
 

--- a/src/test/java/com/example/user/domain/controller/UserControllerTest.java
+++ b/src/test/java/com/example/user/domain/controller/UserControllerTest.java
@@ -1,0 +1,129 @@
+package com.example.user.domain.controller;
+
+import com.example.user.domain.dto.response.UserResponse;
+import com.example.user.domain.service.UserService;
+import com.example.user.global.dto.ResponseDto;
+import com.example.user.global.util.HttpUtil;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@Slf4j
+public class UserControllerTest {
+
+    @Mock
+    private UserService userService;
+
+    @InjectMocks
+    private UserController userController;
+
+    @Test
+    @DisplayName("유효한 userId로 사용자 조회 시 성공적으로 UserResponse를 반환한다")
+    void when_valid_userId_then_findUserById_returns_user_successfully() {
+        // Given
+        String userId = "test123";
+        UserResponse mockUserResponse = mock(UserResponse.class);
+        ResponseDto<UserResponse> mockResponseDto = new ResponseDto<>("find user", mockUserResponse);
+        
+        given(userService.findById(userId)).willReturn(mockUserResponse);
+        
+        try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+            mockedHttpUtil.when(() -> HttpUtil.success("find user", mockUserResponse))
+                    .thenReturn(mockResponseDto);
+            
+            // When
+            ResponseEntity<ResponseDto<UserResponse>> response = userController.findUserById(userId);
+            log.info("response:{}", response.getBody().data().role());
+            
+            // Then
+            assertNotNull(response);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            assertEquals(mockResponseDto, response.getBody());
+            assertEquals("find user", response.getBody().message());
+            assertEquals(mockUserResponse, response.getBody().data());
+            
+            then(userService).should().findById(userId);
+            mockedHttpUtil.verify(() -> HttpUtil.success("find user", mockUserResponse));
+        }
+    }
+
+    @Test
+    @DisplayName("userService.findById가 예외를 던질 때 예외가 전파된다")
+    void when_userService_throws_exception_then_findUserById_propagates_exception() {
+        // Given
+        String userId = "nonexistent";
+        RuntimeException expectedException = new RuntimeException("User not found");
+        
+        given(userService.findById(userId)).willThrow(expectedException);
+        
+        // When & Then
+        RuntimeException actualException = assertThrows(RuntimeException.class,
+                () -> userController.findUserById(userId));
+        
+        assertEquals(expectedException, actualException);
+        then(userService).should().findById(userId);
+    }
+
+    @Test
+    @DisplayName("null userId로 호출해도 userService에 null이 전달된다")
+    void when_null_userId_then_findUserById_passes_null_to_service() {
+        // Given
+        String userId = null;
+        UserResponse mockUserResponse = mock(UserResponse.class);
+        ResponseDto<UserResponse> mockResponseDto = new ResponseDto<>("find user", mockUserResponse);
+        
+        given(userService.findById(null)).willReturn(mockUserResponse);
+        
+        try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+            mockedHttpUtil.when(() -> HttpUtil.success("find user", mockUserResponse))
+                    .thenReturn(mockResponseDto);
+            
+            // When
+            ResponseEntity<ResponseDto<UserResponse>> response = userController.findUserById(userId);
+            
+            // Then
+            assertNotNull(response);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            then(userService).should().findById(null);
+        }
+    }
+
+    @Test
+    @DisplayName("빈 문자열 userId로 호출해도 userService에 빈 문자열이 전달된다")
+    void when_empty_userId_then_findUserById_passes_empty_string_to_service() {
+        // Given
+        String userId = "";
+        UserResponse mockUserResponse = mock(UserResponse.class);
+        ResponseDto<UserResponse> mockResponseDto = new ResponseDto<>("find user", mockUserResponse);
+        
+        given(userService.findById("")).willReturn(mockUserResponse);
+        
+        try (MockedStatic<HttpUtil> mockedHttpUtil = mockStatic(HttpUtil.class)) {
+            mockedHttpUtil.when(() -> HttpUtil.success("find user", mockUserResponse))
+                    .thenReturn(mockResponseDto);
+            
+            // When
+            ResponseEntity<ResponseDto<UserResponse>> response = userController.findUserById(userId);
+            
+            // Then
+            assertNotNull(response);
+            assertEquals(HttpStatus.OK, response.getStatusCode());
+            then(userService).should().findById("");
+        }
+    }
+}

--- a/src/test/java/com/example/user/domain/service/UserServiceUnitTest.java
+++ b/src/test/java/com/example/user/domain/service/UserServiceUnitTest.java
@@ -1,5 +1,6 @@
 package com.example.user.domain.service;
 
+import com.example.user.domain.dto.response.UserIdResponse;
 import com.example.user.domain.model.User;
 import com.example.user.domain.model.UserRole;
 import com.example.user.domain.mapper.UserMapper;
@@ -213,14 +214,14 @@ public class UserServiceUnitTest {
     // Given
     String email = "test@example.com";
     String password = "validPassword";
-    String userId = "testUser";
+    UserIdResponse userId = new UserIdResponse("testUser");
     User user = mock(User.class);
     given(userRepository.findUserByEmail(email)).willReturn(Optional.of(user));
     given(user.equalsPassword(password, passwordEncoder)).willReturn(true);
-    given(user.getUserId()).willReturn(userId);
+    given(user.getUserId()).willReturn(userId.userId());
 
     // When
-    String result = userService.retrieveUserId(email, password);
+    UserIdResponse result = userService.retrieveUserId(email, password);
 
     // Then
     assertEquals(userId, result);


### PR DESCRIPTION
## 🎫 관련 이슈
[//]: # (다음 키워드를 사용하면 해당 PR을 머지할 때 자동으로 이슈를 닫을 수 있습니다.)
[//]: # (keyword: close|closes|closed|resolve|resolves|resolved|fix|fixes|fixed)
[//]: # (예시: close #1)

close #

<br>

## 📄 개요
[//]: # (작업 내용을 간단히 요약해서 적습니다.)
[//]: # (예시: 유저 회원가입 기능을 만들었습니다.)
다름이 아니라, User Profile 조회 시에 User의 Role을 반환하지 않고 있더라고요.
그래서 반환하도록 수정하였습니다. 

더불어, 테스트 코드도 작성하였습니다.
>

<br>

## 🔨 작업 내용
[//]: # (작업 내용을 자세하게 적습니다.)
[//]: # (붙임표 "-" 을 사용해서 목록을 만듭니다.)
[//]: # (예시: 유저 회원가입 API를 만들었습니다.)
다름이 아니라, User Profile 조회 시에 User의 Role을 반환하지 않고 있더라고요.
그래서 반환하도록 수정하였습니다. 

더불어, 테스트 코드도 작성하였습니다.
-


<br>

## 🏁 확인 사항
[//]: # (PR을 보내기 전 다음 사항을 확인해주세요.)
[//]: # (해당 사항을 모두 이행해야 머지할 수 있습니다.)
[//]: # (- [x] 를 사용해서 완료로 표시할 수 있습니다.)

- [ ] 테스트를 완료했나요?
- [ ] API 문서를 작성했나요?
- [ ] 코드 컨벤션을 준수했나요?
- [ ] 불필요한 로그, 주석, import 등을 삭제했나요?

<br>

## 🙋🏻 덧붙일 말
[//]: # (다음 사항이 있다면 적어주세요.)
[//]: # (PR에 대한 추가 설명)
[//]: # (중점적으로 리뷰받고 싶은 부분)
[//]: # (기타 등등)
다름이 아니라, User Profile 조회 시에 User의 Role을 반환하지 않고 있더라고요.
그래서 반환하도록 수정하였습니다. 